### PR TITLE
MM-55: bug fix day buttons nav bar

### DIFF
--- a/src/components/map/RoutePoiButton.scss
+++ b/src/components/map/RoutePoiButton.scss
@@ -27,7 +27,7 @@
   touch-action: manipulation;
   vertical-align: top;
   white-space: nowrap;
-  z-index:2;
+  z-index:1;
   
     &:hover {
       box-shadow: inset 100px 0 0 0 #20afe3;

--- a/src/components/navigation/Navbar.scss
+++ b/src/components/navigation/Navbar.scss
@@ -6,7 +6,7 @@
   top: 20px;
   left: 20px;
   height:100%;
-  z-index: 1;
+  z-index: 2;
   -webkit-user-select: none;
   user-select: none;
   pointer-events: none;
@@ -19,7 +19,7 @@
     position: relative;  
     background: $white;
     border-radius: 3px; 
-    z-index: 1;
+    z-index: 2;
     transform-origin: 4px 0px;
     transition: transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0),
                 background 0.5s cubic-bezier(0.77,0.2,0.05,1.0),


### PR DESCRIPTION
We have made an alteration to the z-indexs of the nav bar and map "POI buttons" - they now sit in the right order so that the buttons do not sit above the nav bar