### PR TITLE
MM-56: Navbar list items auto styling removed

### DIFF
--- a/src/components/funFacts/FunFactPage.scss
+++ b/src/components/funFacts/FunFactPage.scss
@@ -33,6 +33,7 @@ h1 {
   margin-top: 10px;
   margin-bottom: 10px;
   text-align: justify;
+  color: white;
 }
 
 .fun-fact__button {

--- a/src/components/navigation/Navbar.scss
+++ b/src/components/navigation/Navbar.scss
@@ -64,7 +64,6 @@
   padding-top: 125px;
   height:100%;
   background: $secondary;
-  list-style-type: none;
   -webkit-font-smoothing: antialiased;
   /* to stop flickering of text in safari */
   transform-origin: 0% 0%;
@@ -74,6 +73,7 @@
   li {
     padding: 10px 0;
     font-size: 22px;
+    list-style-type: none;
   }
   
   a {


### PR DESCRIPTION
There was a minor bug that meant that the navbar was displaying letters before each list item! 